### PR TITLE
example data fetch hook

### DIFF
--- a/app-frontend/src/components/ApiContext.ts
+++ b/app-frontend/src/components/ApiContext.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+// if you want caching, this is the place for a cache type
+export type Cache = never;
+
+export interface ApiContextShape {
+    api: string;
+    cache?: Cache;
+}
+
+export const ApiContext = createContext<ApiContextShape | undefined>(undefined);

--- a/app-frontend/src/components/Projects/ProjectList/ProjectListWithHooks.tsx
+++ b/app-frontend/src/components/Projects/ProjectList/ProjectListWithHooks.tsx
@@ -1,0 +1,39 @@
+import { Project } from 'actions/projects';
+import React, { Component, Fragment } from 'react';
+import { Link } from 'react-router-dom';
+import { useGetProjects } from 'hooks/projects';
+
+interface Props {
+    projects: Project[];
+}
+
+interface State {
+    filteredProjects: Project[];
+    filter?: string;
+}
+
+function ProjectListWithHooks() {
+    const resourceState = useGetProjects();
+
+    if (resourceState.state === 'error') {
+        return <>error: {resourceState.error}</>;
+    }
+
+    if (
+        resourceState.state === 'not_initialized' ||
+        resourceState.state === 'loading'
+    ) {
+        return <>loading</>;
+    }
+
+    return resourceState.data.map(project => (
+        <li key={project.id}>
+            <Link to={`/project/${project.id}`}>{`#${project.id!} ${
+                project.name
+            }`}</Link>
+            <Link to={`/project/${project.id}/edit`}>🖋️</Link>
+        </li>
+    ));
+}
+
+export default ProjectListWithHooks;

--- a/app-frontend/src/hooks/projects.ts
+++ b/app-frontend/src/hooks/projects.ts
@@ -1,0 +1,27 @@
+import { DraftProject, Project } from 'actions/projects';
+import { useApiResource, ApiResourceState } from './useApiResource';
+import { useApiResourcePost } from './useApiResourcePost';
+
+export function useGetProjects(): ApiResourceState<Project[]> {
+    return useApiResource<Project[]>('/projects');
+}
+
+export function useAddProject(
+    draft: DraftProject
+): [() => Promise<boolean>, ApiResourceState<unknown>] {
+    const [startRequest, apiResourceState] = useApiResourcePost<
+        unknown,
+        DraftProject
+    >('/projects');
+
+    return [
+        () =>
+            startRequest(draft)
+                .then(
+                    ([, response]: [unknown, Response]) =>
+                        response.status === 201
+                )
+                .catch(() => false),
+        apiResourceState
+    ];
+}

--- a/app-frontend/src/hooks/useApiResource.ts
+++ b/app-frontend/src/hooks/useApiResource.ts
@@ -1,0 +1,71 @@
+// tslint:disable
+// this has no use if I don't have your prettierrc
+
+import { ApiContext } from '../components/ApiContext';
+import { useState, useRef, useEffect, useContext } from 'react';
+
+export type ApiResourceState<T> =
+    | {
+          state: 'not_initialized';
+      }
+    | {
+          state: 'loading';
+      }
+    | {
+          state: 'success';
+          data: T;
+      }
+    | {
+          state: 'error';
+          error: Error;
+      };
+
+export function useApiResource<Data, RequestVariables = never>(
+    url: string,
+    data?: RequestVariables
+): ApiResourceState<Data> {
+    const [state, setState] = useState<ApiResourceState<Data>>({
+        state: 'not_initialized'
+    });
+    const api = useContext(ApiContext);
+
+    useEffect(() => {
+        if (!api) {
+            throw new Error(
+                'useApiResource can only be used when wrapped in ApiContext.Provider'
+            );
+        }
+
+        // if you want to add caching, here would be a good place to do something with api.cache
+
+        let abortController: AbortController | null = new AbortController();
+        fetch(`${api.api}${url}`, {
+            method: 'POST',
+            mode: 'cors',
+            cache: 'no-cache',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            redirect: 'follow',
+            referrer: 'no-referrer',
+            body: !data ? undefined : JSON.stringify(data),
+            signal: abortController.signal
+        })
+            .then(response => response.json())
+            .then((data: Data) => {
+                abortController = null;
+                setState({ state: 'success', data });
+            })
+            .catch(e => {
+                if ('name' in e && (e as DOMException).name === 'AbortError') {
+                    setState({ state: 'not_initialized' });
+                } else {
+                    setState({ state: 'error', error: e });
+                }
+            });
+        return () => void (abortController && abortController.abort());
+    }, [url, data]);
+
+    return state;
+}

--- a/app-frontend/src/hooks/useApiResourcePost.ts
+++ b/app-frontend/src/hooks/useApiResourcePost.ts
@@ -1,0 +1,77 @@
+// tslint:disable
+// this has no use if I don't have your prettierrc
+
+import { ApiContext } from '../components/ApiContext';
+import { useState, useRef, useEffect, useContext } from 'react';
+
+export type ApiResourceState<T> =
+    | {
+          state: 'not_initialized';
+      }
+    | {
+          state: 'loading';
+      }
+    | {
+          state: 'success';
+          data: T;
+      }
+    | {
+          state: 'error';
+          error: Error;
+      };
+
+export function useApiResourcePost<Data, RequestVariables = never>(
+    url: string
+): [
+    (data: RequestVariables) => Promise<[Data, Response]>,
+    ApiResourceState<Data>
+] {
+    const [state, setState] = useState<ApiResourceState<Data>>({
+        state: 'not_initialized'
+    });
+    const api = useContext(ApiContext);
+
+    const abortController = useRef<AbortController | undefined>(undefined);
+
+    const startRequest = (data: RequestVariables) => {
+        if (!api) {
+            throw new Error(
+                'useApiResource can only be used when wrapped in ApiContext.Provider'
+            );
+        }
+        if (abortController.current) {
+            abortController.current.abort();
+        }
+        abortController.current = new AbortController();
+        return fetch(`${api.api}${url}`, {
+            method: 'POST',
+            mode: 'cors',
+            cache: 'no-cache',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            redirect: 'follow',
+            referrer: 'no-referrer',
+            body: !data ? undefined : JSON.stringify(data),
+            signal: abortController.current.signal
+        })
+            .then(response => Promise.all([response.json(), response]))
+            .then(([data, response]: [Data, Response]) => {
+                abortController.current = undefined;
+                setState({ state: 'success', data });
+                return [data, response] as [Data, Response];
+            })
+            .catch(e => {
+                if ('name' in e && (e as DOMException).name === 'AbortError') {
+                    setState({ state: 'not_initialized' });
+                    throw e;
+                } else {
+                    setState({ state: 'error', error: e });
+                    throw e;
+                }
+            });
+    };
+
+    return [startRequest, state];
+}

--- a/app-frontend/src/index.tsx
+++ b/app-frontend/src/index.tsx
@@ -4,8 +4,20 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './components/App/App';
 import './index.css';
 import * as serviceWorker from './serviceWorker';
+import { ApiContext, ApiContextShape } from 'components/ApiContext';
 
-ReactDOM.render(<BrowserRouter><App /></BrowserRouter>, document.getElementById('root'));
+const apiContext: ApiContextShape = {
+    api: 'http://localhost:8081'
+};
+
+ReactDOM.render(
+    <BrowserRouter>
+        <ApiContext.Provider value={apiContext}>
+            <App />
+        </ApiContext.Provider>
+    </BrowserRouter>,
+    document.getElementById('root')
+);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
Das ist hier mal ein Beispiel-DataFetchHook.

Was gerade noch nicht passiert ist Caching (ich habe aber ran kommentiert wo man sowas machen würde) und das neu-triggern von fetchs durch einen anderen Post.

Letzteres wäre z.B. lösbar, wenn man dem ApiContextShape noch zwei Methoden  `subscribe(changeCallback: (changedResourceName: string) => void)` und `notifyChange(changedResourceName: string): void` mit geben würde. Dann könnte man an einem Ende der App mitteilen, dass etwas  neu gefetcht wird (neu fetchen würde dann durch einen subscribe innerhalb eines useEffect in useApiResource getriggert)